### PR TITLE
Add missing read alignment in ReplicaManager3::OnConstruction

### DIFF
--- a/Source/ReplicaManager3.cpp
+++ b/Source/ReplicaManager3.cpp
@@ -1185,6 +1185,7 @@ PluginReceiveResult ReplicaManager3::OnConstruction(Packet *packet, unsigned cha
 			}
 		}
 	}
+	bsIn.AlignReadToByteBoundary();
 
 	for (index=0; index < constructionObjectListSize; index++)
 	{


### PR DESCRIPTION
Original - https://github.com/OculusVR/RakNet/pull/63
